### PR TITLE
Add local service account auth, no auto-refresh or cache

### DIFF
--- a/janus.py
+++ b/janus.py
@@ -3,11 +3,18 @@ import requests
 import boto3
 import json
 import sys
+import subprocess
+import socket
+
+# this script originated from https://github.com/doitintl/janus
+# and a blog post https://www.doit.com/assume-an-aws-role-from-a-google-cloud-without-using-iam-keys/
+# modified in order to be able to authenticated using local service account when metadata.google.internal is not available
 
 
 def get_metadata(path: str, parameter: str):
     # Use .format() instead of f-type to support python version before 3.7
-    metadata_url = 'http://metadata.google.internal/computeMetadata/v1/{}/{}'.format(path, parameter)
+    metadata_url = 'http://metadata.google.internal/computeMetadata/v1/{}/{}'.format(
+        path, parameter)
     headers = {'Metadata-Flavor': 'Google'}
     # execute http metadata request
     try:
@@ -21,19 +28,53 @@ def get_metadata(path: str, parameter: str):
         raise SystemExit('Compute Engine meta data error')
 
 
+def get_account_details_local():
+    a_command = '/usr/bin/gcloud config list --format json'
+    config_out_json = subprocess.run(
+        a_command, stdout=subprocess.PIPE, shell=True)
+    config_out = json.loads(config_out_json.stdout.decode('utf-8'))
+
+    return config_out
+
+
+def get_token_local(service_account):
+    # create token for impersonated service account
+    token_command = f'gcloud auth print-identity-token --impersonate-service-account="{service_account}" --audiences="gcp"'
+    # we need to redirect stderr because it produces warning about impersonation
+    token_result = subprocess.run(
+        token_command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        shell=True)
+    token = token_result.stdout.decode('utf-8')
+
+    return token
+
+
 if __name__ == '__main__':
     # Get aws arn from command line argument
     try:
         aws_role_arn = sys.argv[1]
     except IndexError:
-        print('Please specify AWS arn role:\n{} arn:aws:iam::account-id:role/role-name'.format(sys.argv[0]))
+        print(
+            'Please specify AWS arn role:\n{} arn:aws:iam::account-id:role/role-name [local]'.format(sys.argv[0]))
         exit(0)
 
     # Get variables from the metadata server
-    instance_name = get_metadata('instance', 'hostname')
-    project_id = get_metadata('project', 'project-id')
-    project_and_instance_name = '{}.{}'.format(project_id, instance_name)[:64]
-    token = get_metadata('instance', 'service-accounts/default/identity?format=standard&audience=gcp')
+    if len(sys.argv) == 2:
+        instance_name = get_metadata('instance', 'hostname')
+        project_id = get_metadata('project', 'project-id')
+        project_and_instance_name = '{}.{}'.format(
+            project_id, instance_name)[:64]
+        token = get_metadata(
+            'instance', 'service-accounts/default/identity?format=standard&audience=gcp')
+    elif sys.argv[2] == 'local':
+        account_details = get_account_details_local()
+        service_account = account_details["core"]["account"]
+        project_id = account_details["core"]["project"]
+        hostname = socket.gethostname()
+        token = get_token_local(service_account)
+        project_and_instance_name = f'{project_id}-local-{hostname}'
 
     # Assume role using gcp service account token
     sts = boto3.client('sts', aws_access_key_id='', aws_secret_access_key='')

--- a/setcreds
+++ b/setcreds
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+role_arn=$1
+creds_file=$2
+jsonkey=$(/usr/local/bin/janus "${role_arn}" local)
+
+AWS_ACCESS_KEY_ID=$(echo "${jsonkey}" | jq -r '.AccessKeyId')
+AWS_SECRET_ACCESS_KEY=$(echo "${jsonkey}" | jq -r '.SecretAccessKey')
+AWS_SESSION_TOKEN=$(echo "${jsonkey}" | jq -r '.SessionToken')
+AWS_EXPIRATION=$(echo "${jsonkey}" | jq -r '.Expiration')
+
+{
+    echo "[default]"
+    echo "aws_access_key_id = ${AWS_ACCESS_KEY_ID}"
+    echo "aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}"
+    echo "aws_session_token = ${AWS_SESSION_TOKEN}"
+    echo "aws_expiration = ${AWS_EXPIRATION}"
+} >"$creds_file"

--- a/setenv
+++ b/setenv
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+role_arn=$1
+jsonkey=$(/usr/local/bin/janus "${role_arn} local")
+AWSACCESSKEYID=$(echo "${jsonkey}" | jq -r '.AccessKeyId')
+AWSSECRETACCESSKEY=$(echo "${jsonkey}" | jq -r '.SecretAccessKey')
+AWSSESSIONTOKEN=$(echo "${jsonkey}" | jq -r '.SessionToken')
+AWS_EXPIRATION=$(echo "${jsonkey}" | jq -r '.Expiration')
+
+export AWSACCESSKEYID
+export AWSSECRETACCESSKEY
+export AWSSESSIONTOKEN
+export AWS_EXPIRATION

--- a/setjanus
+++ b/setjanus
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+role_arn=$1
+process="/usr/local/bin/janus ${role_arn} local"
+
+cd ~ || exit
+mkdir .aws
+# create credentials file and set it to janus process
+touch ./aws/credentials
+{
+    echo "[default]"
+    echo "credential_process = ${process}"
+} >.aws/credentials


### PR DESCRIPTION
With an additional 'local' parameter, instead of relying on `metadata.google.internal` endpoint being available to generate GCP token - we are using gcloud CLI to get impersonated token.
This PR includes also bash scripts to generate temporary credentials into environment variables or credentials file (when credential_process is not supported - e.g. for s3fs).
`setjanus` sets up a regular configuration where AWS temporary credentials are generated automatically with each subsequent call to AWS CLI